### PR TITLE
fix benchmarker useable http/2

### DIFF
--- a/admin/benchmarker/request.go
+++ b/admin/benchmarker/request.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/http2"
 )
 
 func getInitialize() {
@@ -74,6 +75,9 @@ func httpsRequest(method string, path string, params url.Values) int {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
+	if err := http2.ConfigureTransport(tr); err != nil {
+		log.Fatalf("Failed to configure h2 transport: %s", err)
+	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	client := http.Client{Transport: tr}
 
@@ -91,6 +95,9 @@ func httpsRequestDoc(method string, path string, params url.Values) *goquery.Doc
 	req, _ := http.NewRequest(method, host+path, strings.NewReader(params.Encode()))
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	if err := http2.ConfigureTransport(tr); err != nil {
+		log.Fatalf("Failed to configure h2 transport: %s", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	client := http.Client{Transport: tr}


### PR DESCRIPTION
注意: ベンチマーカーの挙動が一部変わります。

https://qiita.com/catatsuy/items/ee4fc094c6b9c39ee08f

ベンチマーカーがリクエストを送る時、サーバーがhttp/2に対応していればhttp/2で送るようになります。
ただ、クライアントを共有しているわけではないので、現状では点数はそんなに変わらない気がします。
なのでhttp/2の本領である、コネクションの再利用は行いません。
それについては以下の記事参照
https://qiita.com/catatsuy/items/bf3a1a5ffde1f5802d5a
