### PR TITLE
Useable http2 clients

### DIFF
--- a/admin/benchmarker/benchmark.go
+++ b/admin/benchmarker/benchmark.go
@@ -34,6 +34,7 @@ Options:
 		host = "http://127.0.0.1:8080"
 	}
 
+	createClients(*workload * 5)
 	startBenchmark(*workload)
 }
 

--- a/admin/benchmarker/request.go
+++ b/admin/benchmarker/request.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/http2"
 )
 
 func getInitialize() {
@@ -74,6 +75,9 @@ func httpsRequest(method string, path string, params url.Values) int {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
+	if err := http2.ConfigureTransport(tr); err != nil {
+		log.Fatalf("Failed to configure h2 transport: %s", err)
+	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	client := http.Client{Transport: tr}
 
@@ -91,6 +95,9 @@ func httpsRequestDoc(method string, path string, params url.Values) *goquery.Doc
 	req, _ := http.NewRequest(method, host+path, strings.NewReader(params.Encode()))
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	if err := http2.ConfigureTransport(tr); err != nil {
+		log.Fatalf("Failed to configure h2 transport: %s", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	client := http.Client{Transport: tr}


### PR DESCRIPTION
https://github.com/showwin/ISHOCON2/issues/10
の4を実装してみた。
clientを複数個用意して、requestの時にランダムでどれかから送るようにしている。
admin/benchmarker/benchmark.go にworkload\*5としていて、手元の環境ではhttp/2にする事で得点が約1.25倍になる。
ちなみにworkload\*1だと得点が1.5倍くらいに伸びてしまい、幾ら何でもやりすぎだと思った。