### PR TITLE
競技用インストールのOSをUbuntu 18.04に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ ISHOCONとは `Iikanjina SHOwwin CONtest` の略で、[ISUCON](http://isucon.net
 
 ## 問題詳細
 * マニュアル: [ISHOCON2マニュアル](https://github.com/showwin/ISHOCON2/blob/master/doc/manual.md)
-* アプリケーションAMI: `ami-63a8601c`
-* ベンチマーカーAMI: `ami-eb9c4d8a`
+* アプリケーションAMI: `ami-d9b661a6`
+* ベンチマーカーAMI: `ami-78b66107`
 * インスタンスタイプ: `c4.large` (アプリ、ベンチ共に)
 * 参考実装言語: Ruby, Python, Go
 * 推奨実施時間: 1人で8時間

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -5,8 +5,8 @@
 
 ## インスタンスの作成
 AWSのイメージのみ作成しました。
-* アプリケーションAMI: `ami-63a8601c`
-* ベンチマーカーAMI: `ami-eb9c4d8a`
+* アプリケーションAMI: `ami-d9b661a6`
+* ベンチマーカーAMI: `ami-78b66107`
 * アプリケーション、ベンチマーカー共に以下のスペック
   * Instance Type: c4.large
   * Root Volume: 8GB, General Purpose SSD (GP2)


### PR DESCRIPTION
ISHOCON2を作った当時(2016年)のまま更新されていないため、パッケージ管理周りがイマドキでなく、管理コストが高まっていたので、OSのアップデートを実施した。

ref: #13