### PR TITLE
masterブランチにpushされるとDocker Imageを自動でbuild

### DIFF
--- a/admin/REAMDE.md
+++ b/admin/REAMDE.md
@@ -1,3 +1,13 @@
+# イメージの自動 build について
+
+Docker Hubの [automated-build](https://docs.docker.com/docker-hub/builds/#create-an-automated-build) 機能を使って、master ブランチに push されると、自動でイメージをビルドして Docker Hub に登録されるようになっている。
+
+`Dockerfile` とイメージの対応は以下の通り
+
+* `Dockerfile_app`: `ishocon2_app:latest`
+* `Dockerfile_bench`: `ishocon2_bench:latest`
+
+# 手動でやる場合
 ## アプリケーションイメージ作成手順(メモ)
 ```
 $ docker build -f Dockerfile_app . -t showwin/ishocon2_app:$version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
 version: '3.0'
 services:
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile_app
+    image: showwin/ishocon2_app:latest
     command: /docker/start_app.sh
     volumes:
       - storage_app:/var/lib/mysql
@@ -17,9 +15,7 @@ services:
       - /var/lib/mysql
 
   bench:
-    build:
-      context: .
-      dockerfile: Dockerfile_bench
+    image: showwin/ishocon2_bench:latest
     command: /docker/start_bench.sh
     volumes:
       - storage_bench:/var/lib/mysql


### PR DESCRIPTION
Docker Hubの [automated-build](https://docs.docker.com/docker-hub/builds/#create-an-automated-build) 機能を使って、master ブランチに push されると、自動でイメージをビルドして Docker Hub に登録されるようにした。

`Dockerfile` とイメージの対応は以下の通り

* `/Dockerfile_app`: `ishocon2_app:latest`
* `/Dockerfile_bench`: `ishocon2_bench:latest`
