### PR TITLE
ベンチマーカのバグ修正とAMIの更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ ISHOCONとは `Iikanjina SHOwwin CONtest` の略で、[ISUCON](http://isucon.net
 
 ## 問題詳細
 * マニュアル: [ISHOCON2マニュアル](https://github.com/showwin/ISHOCON2/blob/master/doc/manual.md)
-* アプリケーションAMI: `ami-0ec5ab0a6192bf279`
+* アプリケーションAMI: `ami-09568651b65f0daf1`
 * ベンチマーカーAMI: `ami-78b66107`
-* インスタンスタイプ: `c4.large` (アプリ、ベンチ共に)
+* インスタンスタイプ: `c5.large` (アプリ、ベンチ共に)
 * 参考実装言語: Ruby, Python, Go, PHP, NodeJS, Crystal
 * 推奨実施時間: 1人で8時間
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -5,10 +5,10 @@
 
 ## インスタンスの作成
 AWSのイメージのみ作成しました。
-* アプリケーションAMI: `ami-0ec5ab0a6192bf279`
+* アプリケーションAMI: `ami-09568651b65f0daf1`
 * ベンチマーカーAMI: `ami-78b66107`
 * アプリケーション、ベンチマーカー共に以下のスペック
-  * Instance Type: c4.large
+  * Instance Type: c5.large
   * Root Volume: 8GB, General Purpose SSD (GP2)
 
 要望があればGCPでもイメージを作成するかもしれません。


### PR DESCRIPTION
## 変更内容
* [ ] ENAを有効にして、AWSのインスタンスタイプで古いものがサポートされなくなっても起動できるようにする
    * [x] app
    * [ ] bench
* [x] インスタンスタイプをc4.largeからc5.largeに変更
* [ ] benchmarker のTSL Handshakeのタイムアウトで高得点が出ない問題の修正 
    * #29 
    * #32