### PR TITLE
Fix/bench tls timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ISHOCONとは `Iikanjina SHOwwin CONtest` の略で、[ISUCON](http://isucon.net
 ## 問題詳細
 * マニュアル: [ISHOCON2マニュアル](https://github.com/showwin/ISHOCON2/blob/master/doc/manual.md)
 * アプリケーションAMI: `ami-0ec5ab0a6192bf279`
-* ベンチマーカーAMI: `ami-78b66107`
+* ベンチマーカーAMI: `ami-01bb9bea553a65ca8`
 * インスタンスタイプ: `c4.large` (アプリ、ベンチ共に)
 * 参考実装言語: Ruby, Python, Go, PHP, NodeJS, Crystal
 * 推奨実施時間: 1人で8時間

--- a/admin/benchmarker/request.go
+++ b/admin/benchmarker/request.go
@@ -76,9 +76,8 @@ var clients []http.Client
 func createClients(size int) {
 	clients = make([]http.Client, size)
 	for i := 0; i < size; i++ {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		if err := http2.ConfigureTransport(tr); err != nil {
 			log.Fatalf("Failed to configure h2 transport: %s", err)
 		}

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -6,7 +6,7 @@
 ## インスタンスの作成
 AWSのイメージのみ作成しました。
 * アプリケーションAMI: `ami-0ec5ab0a6192bf279`
-* ベンチマーカーAMI: `ami-78b66107`
+* ベンチマーカーAMI: `ami-01bb9bea553a65ca8`
 * アプリケーション、ベンチマーカー共に以下のスペック
   * Instance Type: c4.large
   * Root Volume: 8GB, General Purpose SSD (GP2)


### PR DESCRIPTION
* 796685182d0c8a62017fe51d8904840fff62f7f1 サーバーがTLS Handshakeに失敗したときに、ベンチマーカーがhangしてしまう問題の修正。 
    * #29 
    * #32 
* 401b6739dff74969cfd3f8a6dbd9295d7f208d1a 修正したベンチマーカーを搭載したAMIに変更 