### PR TITLE
Do not access GHA secrets value for dependabot

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,7 @@ jobs:
           - "ruby"
     env:
       ISHOCON_APP_LANG: ${{ matrix.language }}
-      UNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      UNAME: ${{ vars.DOCKER_HUB_USERNAME }}
     steps:
       - uses: actions/checkout@v4
       - name: Replace base image in docker-compose.yml with github actor name
@@ -31,11 +31,6 @@ jobs:
           sed -i 's/ishocon2-bench/${{ env.UNAME }}\/ishocon2-bench/g' ./docker-compose.yml
           sed -i 's/ishocon2-app-${{ env.ISHOCON_APP_LANG }}/${{ env.UNAME }}\/ishocon2-app-${{ env.ISHOCON_APP_LANG }}/g' ./docker-compose.yml
           cat ./docker-compose.yml
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.UNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Build images
         run: |
           make pull || true
@@ -50,4 +45,3 @@ jobs:
     name: Build and push images
     needs: [benchmark]
     uses: './.github/workflows/build_and_push_images.yml'
-    secrets: inherit

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,3 @@ jobs:
       - name: Dump docker logs
         uses: jwalton/gh-docker-logs@v2
         if: ${{ always() }}
-  build:
-    name: Build and push images
-    needs: [benchmark]
-    uses: './.github/workflows/build_and_push_images.yml'

--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -2,15 +2,12 @@ name: Build and push images
 
 on:
     workflow_dispatch:
-    workflow_call:
-      secrets:
-        DOCKER_HUB_USERNAME:
-          required: true
-        DOCKER_HUB_TOKEN:
-          required: true
-    push:
+    workflow_run:
+      workflows: ["Benchmark"]
       branches:
         - master
+      types:
+        - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}


### PR DESCRIPTION
Benchmarkをテストとして実行するだけであれば open な docker image を pull して実行するだけでよく、Docker Hub のログイン情報はいらないので secret values を読みにいかないように変更。